### PR TITLE
Add detection of duplicates of task

### DIFF
--- a/src/main/java/Blitz/TaskList.java
+++ b/src/main/java/Blitz/TaskList.java
@@ -93,6 +93,16 @@ public class TaskList {
     }
 
     /**
+     * Checks whether the specified Task exists in the list of tasks (without comparing status).
+     *
+     * @param task Task to be checked for existence in the list.
+     * @return True if at least one task in the list is considered equal, false otherwise.
+     */
+    public boolean isTaskExist(Task task) {
+        return this.list.stream().anyMatch(t -> t.isEqualWithoutStatus(task));
+    }
+
+    /**
      * Compares two TaskList objects and determines if they are equal.
      *
      * @param o Object to be compared.

--- a/src/main/java/Command/DeadlineCommand.java
+++ b/src/main/java/Command/DeadlineCommand.java
@@ -6,6 +6,7 @@ import blitz.Storage;
 import blitz.TaskList;
 import blitz.Ui;
 
+import exception.BlitzDuplicateTaskException;
 import exception.BlitzException;
 
 import task.Deadline;
@@ -47,6 +48,10 @@ public class DeadlineCommand extends Command {
         assert !description.isBlank() : "Deadline description must not be blank";
 
         Task taskToAdd = new Deadline(description, "D", dateTime, false);
+
+        if (list.isTaskExist(taskToAdd)) {
+            throw new BlitzDuplicateTaskException();
+        }
 
         list.addTask(taskToAdd);
         storage.writeOneToFile(taskToAdd);

--- a/src/main/java/Command/EventCommand.java
+++ b/src/main/java/Command/EventCommand.java
@@ -6,6 +6,7 @@ import blitz.Storage;
 import blitz.TaskList;
 import blitz.Ui;
 
+import exception.BlitzDuplicateTaskException;
 import exception.BlitzException;
 
 import task.Event;
@@ -48,6 +49,10 @@ public class EventCommand extends Command {
         assert !description.isBlank() : "Event description must not be blank";
 
         Task taskToAdd = new Event(description, "E", startDateTime, endDateTime, false);
+
+        if (list.isTaskExist(taskToAdd)) {
+            throw new BlitzDuplicateTaskException();
+        }
 
         list.addTask(taskToAdd);
         storage.writeOneToFile(taskToAdd);

--- a/src/main/java/Command/TodoCommand.java
+++ b/src/main/java/Command/TodoCommand.java
@@ -4,6 +4,7 @@ import blitz.Storage;
 import blitz.TaskList;
 import blitz.Ui;
 
+import exception.BlitzDuplicateTaskException;
 import exception.BlitzException;
 
 import task.Task;
@@ -38,6 +39,10 @@ public class TodoCommand extends Command {
     @Override
     public String execute(TaskList list, Ui ui, Storage storage) throws BlitzException {
         Task taskToAdd = new Todo(this.parameter, "T", false);
+
+        if (list.isTaskExist(taskToAdd)) {
+            throw new BlitzDuplicateTaskException();
+        }
 
         list.addTask(taskToAdd);
         storage.writeOneToFile(taskToAdd);

--- a/src/main/java/Exception/BlitzDuplicateTaskException.java
+++ b/src/main/java/Exception/BlitzDuplicateTaskException.java
@@ -1,0 +1,15 @@
+package exception;
+/**
+ * Represents an exception where a duplicated task is added to the list.
+ */
+public class BlitzDuplicateTaskException extends BlitzException {
+    /**
+     * Returns a String representation of this object.
+     *
+     * @return String indicates there is a duplicated task in the list.
+     */
+    @Override
+    public String toString() {
+        return "The task is already in the list!";
+    }
+}

--- a/src/main/java/Task/Deadline.java
+++ b/src/main/java/Task/Deadline.java
@@ -57,6 +57,24 @@ public class Deadline extends Task {
         return this.type;
     }
 
+    @Override
+    public boolean isEqualWithoutStatus(Task task) {
+        if (this == task) {
+            return true;
+        }
+
+        if (task == null || getClass() != task.getClass()) {
+            return false;
+        }
+
+        Deadline deadline = (Deadline) task;
+        boolean isTypeSame = this.type.equals(deadline.type);
+        boolean isDescriptionSame = super.getDescription().equals(deadline.getDescription());
+        boolean isDateTimeSame = this.dateTime.equals(deadline.dateTime);
+
+        return isTypeSame && isDescriptionSame && isDateTimeSame;
+    }
+
     /**
      * Returns a String representation of this object.
      *
@@ -85,12 +103,9 @@ public class Deadline extends Task {
         }
 
         Deadline deadline = (Deadline) o;
-        boolean isTypeSame = this.type.equals(deadline.type);
-        boolean isDescriptionSame = super.getDescription().equals(deadline.getDescription());
-        boolean isDateTimeSame = this.dateTime.equals(deadline.dateTime);
         boolean isStatusSame = super.isDone() == deadline.isDone();
 
-        return isTypeSame && isDescriptionSame && isDateTimeSame && isStatusSame;
+        return isEqualWithoutStatus(deadline) && isStatusSame;
     }
 }
 

--- a/src/main/java/Task/Event.java
+++ b/src/main/java/Task/Event.java
@@ -63,6 +63,25 @@ public class Event extends Task {
         return this.type;
     }
 
+    @Override
+    public boolean isEqualWithoutStatus(Task task) {
+        if (this == task) {
+            return true;
+        }
+
+        if (task == null || getClass() != task.getClass()) {
+            return false;
+        }
+
+        Event event = (Event) task;
+        boolean isTypeSame = this.type.equals(event.type);
+        boolean isDescriptionSame = super.getDescription().equals(event.getDescription());
+        boolean isStartDateTimeSame = this.startDateTime.equals(event.startDateTime);
+        boolean isEndDateTimeSame = this.endDateTime.equals(event.endDateTime);
+
+        return isTypeSame && isDescriptionSame && isStartDateTimeSame && isEndDateTimeSame;
+    }
+
     /**
      * Returns a String representation of this object.
      *
@@ -93,12 +112,8 @@ public class Event extends Task {
         }
 
         Event event = (Event) o;
-        boolean isTypeSame = this.type.equals(event.type);
-        boolean isDescriptionSame = super.getDescription().equals(event.getDescription());
-        boolean isStartDateTimeSame = this.startDateTime.equals(event.startDateTime);
-        boolean isEndDateTimeSame = this.endDateTime.equals(event.endDateTime);
         boolean isStatusSame = super.isDone() == event.isDone();
 
-        return isTypeSame && isDescriptionSame && isStartDateTimeSame && isEndDateTimeSame && isStatusSame;
+        return isEqualWithoutStatus(event) && isStatusSame;
     }
 }

--- a/src/main/java/Task/Task.java
+++ b/src/main/java/Task/Task.java
@@ -131,6 +131,16 @@ public abstract class Task {
      */
     public abstract String convertTaskToString();
 
+
+    /**
+     * Compares two Task objects and determines if they are equal without considering status.
+     *
+     * @param task Task to be compared.
+     * @return True if both objects are of same reference or all attributes (except status)
+     *     in both objects are the same, false otherwise.
+     */
+    public abstract boolean isEqualWithoutStatus(Task task);
+
     /**
      * Returns a String representation of this object.
      *

--- a/src/main/java/Task/Todo.java
+++ b/src/main/java/Task/Todo.java
@@ -38,6 +38,23 @@ public class Todo extends Task {
         return this.type;
     }
 
+    @Override
+    public boolean isEqualWithoutStatus(Task task) {
+        if (this == task) {
+            return true;
+        }
+
+        if (task == null || getClass() != task.getClass()) {
+            return false;
+        }
+
+        Todo todo = (Todo) task;
+        boolean isTypeSame = this.type.equals(todo.type);
+        boolean isDescriptionSame = super.getDescription().equals(todo.getDescription());
+
+        return isTypeSame && isDescriptionSame;
+    }
+
     /**
      * Compares two Todo objects and determines if they are equal.
      *
@@ -56,10 +73,8 @@ public class Todo extends Task {
         }
 
         Todo todo = (Todo) o;
-        boolean isTypeSame = this.type.equals(todo.type);
-        boolean isDescriptionSame = super.getDescription().equals(todo.getDescription());
         boolean isStatusSame = super.isDone() == todo.isDone();
 
-        return isTypeSame && isDescriptionSame && isStatusSame;
+        return isEqualWithoutStatus(todo) && isStatusSame;
     }
 }


### PR DESCRIPTION
User should not be able to add duplicated task into the list (regardless the task in the list is marked done or undone).

Application now is able to detect such duplicates. Exception will be thrown if user trying to add duplicated task.

Another comparing method is added to Task objects to not compare status unlike the overridden equals method.